### PR TITLE
Fix formatting characters

### DIFF
--- a/library/src/main/java/co/fusionx/relay/base/FormatSpanInfo.java
+++ b/library/src/main/java/co/fusionx/relay/base/FormatSpanInfo.java
@@ -1,5 +1,7 @@
 package co.fusionx.relay.base;
 
+import com.google.common.base.MoreObjects;
+
 public class FormatSpanInfo {
     public final int start;
     public final int end;
@@ -47,5 +49,41 @@ public class FormatSpanInfo {
         this.end = end;
         this.format = format;
         this.fgColor = this.bgColor = null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        FormatSpanInfo that = (FormatSpanInfo) o;
+
+        if (start != that.start) return false;
+        if (end != that.end) return false;
+        if (format != that.format) return false;
+        if (fgColor != that.fgColor) return false;
+        return bgColor == that.bgColor;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = start;
+        result = 31 * result + end;
+        result = 31 * result + format.hashCode();
+        result = 31 * result + (fgColor != null ? fgColor.hashCode() : 0);
+        result = 31 * result + (bgColor != null ? bgColor.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("start", start)
+                .add("end", end)
+                .add("format", format)
+                .add("fgColor", fgColor)
+                .add("bgColor", bgColor)
+                .toString();
     }
 }

--- a/library/src/main/java/co/fusionx/relay/util/Utils.java
+++ b/library/src/main/java/co/fusionx/relay/util/Utils.java
@@ -10,55 +10,95 @@ import co.fusionx.relay.base.FormatSpanInfo;
 
 public class Utils {
 
+    private static final char IRC_BOLD = '\u0002';
+    private static final char IRC_COLOR = '\u0003';
+    private static final char IRC_ITALIC = '\u001d';
+    private static final char IRC_UNDERLINE = '\u001f';
+    private static final char IRC_RESET_FORMATTING = '\u000f';
+
     public static boolean isNotEmpty(final CharSequence cs) {
         return !TextUtils.isEmpty(cs);
     }
 
     private static class FormatState {
+        private static final int NOT_OPEN = -1;
+
         private List<FormatSpanInfo> mFormats;
-        private int mBoldStart = -1, mColorStart = -1;
-        private int mItalicStart = -1, mUnderlineStart = -1;
+        private int mBoldStart = NOT_OPEN, mColorStart = NOT_OPEN;
+        private int mItalicStart = NOT_OPEN, mUnderlineStart = NOT_OPEN;
         FormatSpanInfo.Color mFgColor = null, mBgColor = null;
 
         void bold(int pos) {
-            if (mBoldStart < 0) mBoldStart = pos;
+            if (mBoldStart >= 0 && mBoldStart < pos) {
+                addBold(mBoldStart, pos);
+                mBoldStart = NOT_OPEN;
+            } else {
+                mBoldStart = pos;
+            }
         }
 
         void italic(int pos) {
-            if (mItalicStart < 0) mItalicStart = pos;
+            if (mItalicStart >= 0 && mItalicStart < pos) {
+                addItalic(mItalicStart, pos);
+                mItalicStart = NOT_OPEN;
+            } else {
+                mItalicStart = pos;
+            }
         }
 
         void underline(int pos) {
-            if (mUnderlineStart < 0) mUnderlineStart = pos;
+            if (mUnderlineStart >= 0 && mUnderlineStart < pos) {
+                addUnderline(mUnderlineStart, pos);
+                mUnderlineStart = NOT_OPEN;
+            } else {
+                mUnderlineStart = pos;
+            }
         }
 
         void color(int pos, FormatSpanInfo.Color fg, FormatSpanInfo.Color bg) {
             if (mColorStart >= 0 && pos > 0 && mFgColor != null) {
-                addFormat(new FormatSpanInfo(mColorStart, pos, mFgColor, mBgColor));
+               addColor(mColorStart, pos, mFgColor, mBgColor);
             }
             mColorStart = pos;
             mFgColor = fg;
             mBgColor = bg;
         }
 
-        void apply(int pos) {
+        void applyAndReset(int pos) {
             if (pos == 0) {
                 return;
             }
             if (mColorStart >= 0 && mColorStart < pos && mFgColor != null) {
-                addFormat(new FormatSpanInfo(mColorStart, pos, mFgColor, mBgColor));
+                addColor(mColorStart, pos, mFgColor, mBgColor);
             }
             if (mBoldStart >= 0 && mBoldStart < pos) {
-                addFormat(new FormatSpanInfo(mBoldStart, pos, FormatSpanInfo.Format.BOLD));
+                addBold(mBoldStart, pos);
             }
             if (mItalicStart >= 0 && mItalicStart < pos) {
-                addFormat(new FormatSpanInfo(mItalicStart, pos,
-                        FormatSpanInfo.Format.ITALIC));
+                addItalic(mItalicStart, pos);
             }
             if (mUnderlineStart >= 0 && mUnderlineStart < pos) {
-                addFormat(new FormatSpanInfo(mUnderlineStart, pos,
-                        FormatSpanInfo.Format.UNDERLINED));
+                addUnderline(mUnderlineStart, pos);
             }
+
+            mColorStart = mBoldStart = mItalicStart = mUnderlineStart = NOT_OPEN;
+        }
+
+        private void addBold(int start, int end) {
+            addFormat(new FormatSpanInfo(start, end, FormatSpanInfo.Format.BOLD));
+        }
+
+        private void addItalic(int start, int end) {
+            addFormat(new FormatSpanInfo(start, end, FormatSpanInfo.Format.ITALIC));
+        }
+
+        private void addUnderline(int start, int end) {
+            addFormat(new FormatSpanInfo(start, end, FormatSpanInfo.Format.UNDERLINED));
+        }
+
+        private void addColor(int start, int end, FormatSpanInfo.Color fgColor,
+                              FormatSpanInfo.Color bgColor) {
+            addFormat(new FormatSpanInfo(start, end, fgColor, bgColor));
         }
 
         private void addFormat(FormatSpanInfo info) {
@@ -80,12 +120,9 @@ public class Utils {
         while (i < length) {
             char c = line.charAt(i++);
 
-            if (c == '\u0002') {
-                // bold
+            if (c == IRC_BOLD) {
                 state.bold(buffer.length());
-            } else if (c == '\u0003') {
-                // color
-
+            } else if (c == IRC_COLOR) {
                 int firstFgDigit = digitValue(line, i);
                 int secondFgDigit = digitValue(line, i + 1);
                 // advance over read digits
@@ -121,20 +158,17 @@ public class Utils {
                     }
                 }
                 state.color(buffer.length(), fg, bg);
-            } else if (c == '\u001d') {
-                // italic
+            } else if (c == IRC_ITALIC) {
                 state.italic(buffer.length());
-            } else if (c == '\u001f') {
-                // underline
+            } else if (c == IRC_UNDERLINE) {
                 state.underline(buffer.length());
-            } else if (c == '\u000f') {
-                // end formatting
-                state.apply(buffer.length());
+            } else if (c == IRC_RESET_FORMATTING) {
+                state.applyAndReset(buffer.length());
             } else {
                 buffer.append(c);
             }
         }
-        state.apply(buffer.length());
+        state.applyAndReset(buffer.length());
         return Pair.create(buffer.toString(), state.mFormats);
     }
 

--- a/library/src/test/java/co/fusionx/relay/internal/base/TestUtils.java
+++ b/library/src/test/java/co/fusionx/relay/internal/base/TestUtils.java
@@ -5,7 +5,9 @@ import android.util.Log;
 import co.fusionx.relay.base.Server;
 import co.fusionx.relay.base.ServerConfiguration;
 import co.fusionx.relay.interfaces.RelayConfiguration;
+import co.fusionx.relay.internal.sender.BaseSender;
 import co.fusionx.relay.internal.sender.RelayBaseSender;
+import co.fusionx.relay.internal.sender.RelayServerSender;
 import co.fusionx.relay.misc.NickStorage;
 
 public class TestUtils {
@@ -41,8 +43,8 @@ public class TestUtils {
 
     public static RelayServer getFreenodeServer() {
         final ServerConfiguration freenode = getFreenodeConfiguration();
-        final RelayIRCConnection connection = getConnection(freenode);
-        return getServerFromConnection(connection);
+        final BaseSender baseSender = new RelayBaseSender();
+        return new RelayServer(freenode, baseSender, new RelayServerSender(baseSender));
     }
 
     public static RelayServer getServerFromConfiguration(final ServerConfiguration configuration) {

--- a/library/src/test/java/co/fusionx/relay/util/UtilsTest.java
+++ b/library/src/test/java/co/fusionx/relay/util/UtilsTest.java
@@ -1,0 +1,70 @@
+package co.fusionx.relay.util;
+
+import android.util.Pair;
+import co.fusionx.relay.base.FormatSpanInfo;
+import co.fusionx.relay.base.FormatSpanInfo.Color;
+import co.fusionx.relay.base.FormatSpanInfo.Format;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.List;
+
+import static co.fusionx.relay.util.Utils.parseAndStripColorsFromMessage;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Config(emulateSdk = 18)
+@RunWith(RobolectricTestRunner.class)
+public class UtilsTest {
+    private static final char IRC_BOLD = '\u0002';
+    private static final char IRC_COLOR = '\u0003';
+    private static final char IRC_ITALIC = '\u001d';
+    private static final char IRC_UNDERLINE = '\u001f';
+    private static final char IRC_RESET_FORMATTING = '\u000f';
+
+    @Test
+    public void parseAndStripColorsFromMessage_overlappingFormatting() throws Exception {
+        String testMessage = String.format(
+                "%1$sTest%1$s %2$sM%3$ses%2$ss%3$sage",
+                IRC_BOLD,
+                IRC_UNDERLINE,
+                IRC_ITALIC);
+        Pair<String, List<FormatSpanInfo>> actual = parseAndStripColorsFromMessage(testMessage);
+
+        assertThat(actual.first).isEqualTo("Test Message");
+        assertThat(actual.second).containsOnly(
+                new FormatSpanInfo(0, 4, Format.BOLD),
+                new FormatSpanInfo(5, 8, Format.UNDERLINED),
+                new FormatSpanInfo(6, 9, Format.ITALIC));
+    }
+
+    @Test
+    public void parseAndStripColorsFromMessage_colorCodes() throws Exception {
+        String testMessage = String.format(
+                "T%1$s3,5es%1$s03,05t%1$s Me%1$s3s%1$s05sa%1$sge%1$s",
+                IRC_COLOR);
+        Pair<String, List<FormatSpanInfo>> actual = parseAndStripColorsFromMessage(testMessage);
+        assertThat(actual.first).isEqualTo("Test Message");
+        assertThat(actual.second).containsOnly(
+                new FormatSpanInfo(1, 3, Color.GREEN, Color.BROWN),
+                new FormatSpanInfo(3, 4, Color.GREEN, Color.BROWN),
+                new FormatSpanInfo(7, 8, Color.GREEN, null),
+                new FormatSpanInfo(8, 10, Color.BROWN, null));
+    }
+
+    @Test
+    public void parseAndStripColorsFromMessage_reset() throws Exception {
+        String testMessage = String.format(
+                "%sTe%sst%s Message",
+                IRC_BOLD,
+                IRC_UNDERLINE,
+                IRC_RESET_FORMATTING);
+        Pair<String, List<FormatSpanInfo>> actual = parseAndStripColorsFromMessage(testMessage);
+        assertThat(actual.first).isEqualTo("Test Message");
+        assertThat(actual.second).containsOnly(
+                new FormatSpanInfo(0, 4, Format.BOLD),
+                new FormatSpanInfo(2, 4, Format.UNDERLINED));
+    }
+
+}


### PR DESCRIPTION
The old implementation of line format parsing exhibited incorrect behavior, in that each of the formatting regions is normally closed by a matching character (a la HTML), not \x0F.
